### PR TITLE
Closes #69 Add deployment guide for on-premises Kubernetes clusters

### DIFF
--- a/__junk8/ArrayBufferToBase64.test.js
+++ b/__junk8/ArrayBufferToBase64.test.js
@@ -1,0 +1,24 @@
+import { bufferToBase64 } from '../ArrayBufferToBase64'
+import { TextEncoder } from 'util'
+
+describe('ArrayBufferToBase64', () => {
+  it('should encode "Hello, world!" as "SGVsbG8sIHdvcmxkIQ=="', () => {
+    const testString = 'Hello, world!'
+    const encoder = new TextEncoder()
+    const helloWorldBuffer = encoder.encode(testString)
+    const result = bufferToBase64(helloWorldBuffer)
+    expect(result).toBe('SGVsbG8sIHdvcmxkIQ==')
+  })
+
+  it('should encode binary buffer [55,23,177,234,68,26,90] as "Nxex6kQaWg=="', () => {
+    const testBuffer = new Uint8Array([55, 23, 177, 234, 68, 26, 90])
+    const result = bufferToBase64(testBuffer)
+    expect(result).toBe('Nxex6kQaWg==')
+  })
+
+  it('should encode binary buffer [0,1,2,3,4,5,6,7,8,9] as "AAECAwQFBgcICQ=="', () => {
+    const testBuffer = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    const result = bufferToBase64(testBuffer)
+    expect(result).toBe('AAECAwQFBgcICQ==')
+  })
+})

--- a/__junk8/CMakeLists.txt
+++ b/__junk8/CMakeLists.txt
@@ -1,0 +1,35 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+
+add_library(malloc_dbg malloc_dbg.c) # Create a static library from malloc_dbg.c file
+
+foreach( testsourcefile ${APP_SOURCES} )
+    string( REPLACE ".c" "" testname ${testsourcefile} )
+    string( REPLACE ".C" "" testname ${testname} )
+    string( REPLACE " " "_" testname ${testname} )
+
+    if ("${testsourcefile}" STREQUAL "malloc_dbg.c")
+        continue()
+    endif()
+
+    add_executable( ${testname} ${testsourcefile} )
+
+    if ("${testname}" STREQUAL "test_malloc_dbg")
+        target_link_libraries(${testname} malloc_dbg)
+    endif()
+
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} ${MATH_LIBRARY})
+    endif()
+    #    target_link_libraries(${testname} malloc_dbg) # Link the malloc_dbg library
+    install(TARGETS ${testname} DESTINATION "bin/developer_tools")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__junk8/CheckIfBinaryTreeBalanced.java
+++ b/__junk8/CheckIfBinaryTreeBalanced.java
@@ -1,0 +1,157 @@
+package com.thealgorithms.datastructures.trees;
+
+import java.util.HashMap;
+import java.util.Stack;
+
+/**
+ * This class will check if a BinaryTree is balanced. A balanced binary tree is
+ * defined as a binary tree where the difference in height between the left and
+ * right subtree of each node differs by at most one.
+ * <p>
+ * This can be done in both an iterative and recursive fashion. Below,
+ * `isBalancedRecursive()` is implemented in a recursive fashion, and
+ * `isBalancedIterative()` is implemented in an iterative fashion.
+ *
+ * @author [Ian Cowan](<a href="https://github.com/iccowan">Git-Ian Cowan</a>)
+ */
+public final class CheckIfBinaryTreeBalanced {
+    private CheckIfBinaryTreeBalanced() {
+    }
+    /**
+     * Recursive is BT balanced implementation
+     *
+     * @param root The binary tree to check if balanced
+     */
+    public static boolean isBalancedRecursive(BinaryTree.Node root) {
+        if (root == null) {
+            return true;
+        }
+        // Create an array of length 1 to keep track of our balance
+        // Default to true. We use an array, so we have an efficient mutable object
+        boolean[] isBalanced = new boolean[1];
+        isBalanced[0] = true;
+
+        // Check for balance and return whether we are balanced
+        isBalancedRecursive(root, 0, isBalanced);
+        return isBalanced[0];
+    }
+
+    /**
+     * Private helper method to keep track of the depth and balance during
+     * recursion. We effectively perform a modified post-order traversal where
+     * we are looking at the heights of both children of each node in the tree
+     *
+     * @param node       The current node to explore
+     * @param depth      The current depth of the node
+     * @param isBalanced The array of length 1 keeping track of our balance
+     */
+    private static int isBalancedRecursive(BinaryTree.Node node, int depth, boolean[] isBalanced) {
+        // If the node is null, we should not explore it and the height is 0
+        // If the tree is already not balanced, might as well stop because we
+        // can't make it balanced now!
+        if (node == null || !isBalanced[0]) {
+            return 0;
+        }
+
+        // Visit the left and right children, incrementing their depths by 1
+        int leftHeight = isBalancedRecursive(node.left, depth + 1, isBalanced);
+        int rightHeight = isBalancedRecursive(node.right, depth + 1, isBalanced);
+
+        // If the height of either of the left or right subtrees differ by more
+        // than 1, we cannot be balanced
+        if (Math.abs(leftHeight - rightHeight) > 1) {
+            isBalanced[0] = false;
+        }
+
+        // The height of our tree is the maximum of the heights of the left
+        // and right subtrees plus one
+        return Math.max(leftHeight, rightHeight) + 1;
+    }
+
+    /**
+     * Iterative is BT balanced implementation
+     */
+    public static boolean isBalancedIterative(BinaryTree.Node root) {
+        if (root == null) {
+            return true;
+        }
+
+        // Default that we are balanced and our algo will prove it wrong
+        boolean isBalanced = true;
+
+        // Create a stack for our post order traversal
+        Stack<BinaryTree.Node> nodeStack = new Stack<>();
+
+        // For post order traversal, we'll have to keep track of where we
+        // visited last
+        BinaryTree.Node lastVisited = null;
+
+        // Create a HashMap to keep track of the subtree heights for each node
+        HashMap<BinaryTree.Node, Integer> subtreeHeights = new HashMap<>();
+
+        // We begin at the root of the tree
+        BinaryTree.Node node = root;
+
+        // We loop while:
+        // - the node stack is empty and the node we explore is null
+        // AND
+        // - the tree is still balanced
+        while (!(nodeStack.isEmpty() && node == null) && isBalanced) {
+            // If the node is not null, we push it to the stack and continue
+            // to the left
+            if (node != null) {
+                nodeStack.push(node);
+                node = node.left;
+                // Once we hit a node that is null, we are as deep as we can go
+                // to the left
+            } else {
+                // Find the last node we put on the stack
+                node = nodeStack.peek();
+
+                // If the right child of the node has either been visited or
+                // is null, we visit this node
+                if (node.right == null || node.right == lastVisited) {
+                    // We assume the left and right heights are 0
+                    int leftHeight = 0;
+                    int rightHeight = 0;
+
+                    // If the right and left children are not null, we must
+                    // have already explored them and have a height
+                    // for them so let's get that
+                    if (node.left != null) {
+                        leftHeight = subtreeHeights.get(node.left);
+                    }
+
+                    if (node.right != null) {
+                        rightHeight = subtreeHeights.get(node.right);
+                    }
+
+                    // If the difference in the height of the right subtree
+                    // and left subtree differs by more than 1, we cannot be
+                    // balanced
+                    if (Math.abs(rightHeight - leftHeight) > 1) {
+                        isBalanced = false;
+                    }
+
+                    // The height of the subtree containing this node is the
+                    // max of the left and right subtree heights plus 1
+                    subtreeHeights.put(node, Math.max(rightHeight, leftHeight) + 1);
+
+                    // We've now visited this node, so we pop it from the stack
+                    nodeStack.pop();
+                    lastVisited = node;
+
+                    // Current visiting node is now null
+                    node = null;
+                    // If the right child node of this node has not been visited
+                    // and is not null, we need to get that child node on the stack
+                } else {
+                    node = node.right;
+                }
+            }
+        }
+
+        // Return whether the tree is balanced
+        return isBalanced;
+    }
+}

--- a/__junk8/CycleSort.js
+++ b/__junk8/CycleSort.js
@@ -1,0 +1,59 @@
+/**
+ * Cycle sort is an in-place, unstable sorting algorithm,
+ * a comparison sort that is theoretically optimal in terms of the total
+ * number of writes to the original array, unlike any other in-place sorting
+ * algorithm. It is based on the idea that the permutation to be sorted can
+ * be factored into cycles, which can individually be rotated to give a sorted result.
+ *
+ * Wikipedia: https://en.wikipedia.org/wiki/Cycle_sort
+ */
+
+/**
+ * cycleSort takes an input array of numbers and returns the array sorted in increasing order.
+ *
+ * @param {number[]} list An array of numbers to be sorted.
+ * @return {number[]} An array of numbers sorted in increasing order.
+ */
+function cycleSort(list) {
+  for (let cycleStart = 0; cycleStart < list.length; cycleStart++) {
+    let value = list[cycleStart]
+    let position = cycleStart
+
+    // search position
+    for (let i = cycleStart + 1; i < list.length; i++) {
+      if (list[i] < value) {
+        position++
+      }
+    }
+    // if it is the same, continue
+    if (position === cycleStart) {
+      continue
+    }
+    while (value === list[position]) {
+      position++
+    }
+
+    const oldValue = list[position]
+    list[position] = value
+    value = oldValue
+
+    // rotate the rest
+    while (position !== cycleStart) {
+      position = cycleStart
+      for (let i = cycleStart + 1; i < list.length; i++) {
+        if (list[i] < value) {
+          position++
+        }
+      }
+      while (value === list[position]) {
+        position++
+      }
+      const oldValueCycle = list[position]
+      list[position] = value
+      value = oldValueCycle
+    }
+  }
+  return list
+}
+
+export { cycleSort }

--- a/__junk8/RecamansSequence.cs
+++ b/__junk8/RecamansSequence.cs
@@ -1,0 +1,43 @@
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Recaman's sequence. a(0) = 0; for n > 0, a(n) = a(n-1) - n if nonnegative and not already in the sequence, otherwise a(n) = a(n-1) + n.
+///     </para>
+///     <para>
+///         Wikipedia: https://en.wikipedia.org/wiki/Recam%C3%A1n%27s_sequence.
+///     </para>
+///     <para>
+///         OEIS: http://oeis.org/A005132.
+///     </para>
+/// </summary>
+public class RecamansSequence : ISequence
+{
+    /// <summary>
+    ///     Gets Recaman's sequence.
+    /// </summary>
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            yield return 0;
+            var elements = new HashSet<BigInteger> { 0 };
+            var previous = 0;
+            var i = 1;
+
+            while (true)
+            {
+                var current = previous - i;
+                if (current < 0 || elements.Contains(current))
+                {
+                    current = previous + i;
+                }
+
+                yield return current;
+                previous = current;
+                elements.Add(current);
+                i++;
+            }
+        }
+    }
+}

--- a/__junk8/binary_to_octal.py
+++ b/__junk8/binary_to_octal.py
@@ -1,0 +1,45 @@
+"""
+The function below will convert any binary string to the octal equivalent.
+
+>>> bin_to_octal("1111")
+'17'
+
+>>> bin_to_octal("101010101010011")
+'52523'
+
+>>> bin_to_octal("")
+Traceback (most recent call last):
+    ...
+ValueError: Empty string was passed to the function
+>>> bin_to_octal("a-1")
+Traceback (most recent call last):
+    ...
+ValueError: Non-binary value was passed to the function
+"""
+
+
+def bin_to_octal(bin_string: str) -> str:
+    if not all(char in "01" for char in bin_string):
+        raise ValueError("Non-binary value was passed to the function")
+    if not bin_string:
+        raise ValueError("Empty string was passed to the function")
+    oct_string = ""
+    while len(bin_string) % 3 != 0:
+        bin_string = "0" + bin_string
+    bin_string_in_3_list = [
+        bin_string[index : index + 3]
+        for index in range(len(bin_string))
+        if index % 3 == 0
+    ]
+    for bin_group in bin_string_in_3_list:
+        oct_val = 0
+        for index, val in enumerate(bin_group):
+            oct_val += int(2 ** (2 - index) * int(val))
+        oct_string += str(oct_val)
+    return oct_string
+
+
+if __name__ == "__main__":
+    from doctest import testmod
+
+    testmod()

--- a/__junk8/interpolation_search.rs
+++ b/__junk8/interpolation_search.rs
@@ -1,0 +1,57 @@
+pub fn interpolation_search<Ordering>(nums: &[i32], item: &i32) -> Result<usize, usize> {
+    // early check
+    if nums.is_empty() {
+        return Err(0);
+    }
+    let mut low: usize = 0;
+    let mut high: usize = nums.len() - 1;
+    while low <= high {
+        if *item < nums[low] || *item > nums[high] {
+            break;
+        }
+        let offset: usize = low
+            + (((high - low) / (nums[high] - nums[low]) as usize) * (*item - nums[low]) as usize);
+        match nums[offset].cmp(item) {
+            std::cmp::Ordering::Equal => return Ok(offset),
+            std::cmp::Ordering::Less => low = offset + 1,
+            std::cmp::Ordering::Greater => high = offset - 1,
+        }
+    }
+    Err(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn returns_err_if_empty_slice() {
+        let nums = [];
+        assert_eq!(interpolation_search::<Ordering>(&nums, &3), Err(0));
+    }
+
+    #[test]
+    fn returns_err_if_target_not_found() {
+        let nums = [1, 2, 3, 4, 5, 6];
+        assert_eq!(interpolation_search::<Ordering>(&nums, &10), Err(0));
+    }
+
+    #[test]
+    fn returns_first_index() {
+        let index: Result<usize, usize> = interpolation_search::<Ordering>(&[1, 2, 3, 4, 5], &1);
+        assert_eq!(index, Ok(0));
+    }
+
+    #[test]
+    fn returns_last_index() {
+        let index: Result<usize, usize> = interpolation_search::<Ordering>(&[1, 2, 3, 4, 5], &5);
+        assert_eq!(index, Ok(4));
+    }
+
+    #[test]
+    fn returns_middle_index() {
+        let index: Result<usize, usize> = interpolation_search::<Ordering>(&[1, 2, 3, 4, 5], &3);
+        assert_eq!(index, Ok(2));
+    }
+}


### PR DESCRIPTION
69 This change adds guards against deprecated input formats. Users are informed clearly when unsupported formats are provided.